### PR TITLE
Fixes to the installation of the bot as well as service file fixes. Readme also updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,74 +8,33 @@ _Continuous Testing & Integration not implemented yet_
 
 ## Requirements
 
+- Ubuntu 24.04 or later
 - NodeJS 18.x (Recommend NodeJS repository for latest security updates: https://nodejs.org/en/download/package-manager/) (For Windows Admins: Make sure NodeJS is installed to the system $PATH)
 - TypeScript ^4.x (Installed during `npm install`) (For Windows Admins: Install this manually & globally - `npm install -g typescript`)
 - Prisma ^4.8.x (Installed during `npm install`)
-- sqlite3 package (Optional, Linux Only)
+- PostgreSQL
 
 ## Automatic Installation - Linux
 
-**IMPORTANT**: You will need to install `git` and `sqlite3` on your system
+**Prerequisites**
 
-To run the automated install, paste and execute the following command in your terminal: `curl https://raw.githubusercontent.com/givelotus/lotus-bot/main/install.sh | sudo bash`
+Please install the following packages on your system for the automatic installer to work:
 
-After the installation completes, you will need to edit your `/opt/lotus-bot/.env` file to fill in the appropriate values for your platform!
+- git
+- postgresql
+
+To run the automated install, paste and execute the following command in your terminal: `curl https://github.com/LotusiaStewardship/lotus-bot/main/install.sh | sudo bash`
+
+After the installation completes, you will need to edit your `/opt/lotusbot/.env` file to fill in the appropriate values for your platform!
 
 The `install.sh` script will:
 
-- Clone this repository to `/opt/lotus-bot` directory
-- Create a new system user with the repository as its `$HOME` folder and ensure proper permissions
+- Clone this repository to `/opt/lotusbot` directory
+- Create a new system user with login disabled for the systemd service
 - Create the `.env` config file
-- Install NPM dependencies
-- Set up Prisma and sqlite3 database
+- Install NVM & NPM dependencies
+- Set up Prisma and PostgreSQL database
 - Install systemd service
-
-## Manual Install
-
-If you prefer to not run the Automatic Install, or if you are running Windows, follow the below prcoedure.
-
-### Install (Linux)
-
-1. Install sqlite3 per your distribution's package management system
-2. Set up the folder to hold the repo - `sudo mkdir -p /opt/lotus-bot`
-3. Clone the repo - `sudo git clone https://github.com/givelotus/lotus-bot.git /opt/lotus-bot`
-4. Open the folder in your favorite terminal
-5. Then `cp .env.example .env`
-6. Modify `.env` with the required API key(s) for the bot(s) you want to run.
-7. Install dependencies: `npm install`
-8. Initialize the Database:
-
-```
-npx prisma migrate dev --name init
-sqlite3 ./prisma/dev.db 'PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;'
-```
-
-9. systemd is supported, you can install the service unit from the `install/` folder:
-
-```
-sudo cp ./install/lotus-bot.service /etc/systemd/system
-sudo systemctl daemon-reload
-```
-
-### Install (Windows)
-
-1. Install typescript globally: `npm install -g typescript` (This will require Administrator Rights)
-2. Setup a folder to hold the repo, example: `C:\Lotus\lotus-bot`
-3. Clone the repo into said folder: `git clone https://github.com/givelotus/lotus-bot.git C:\Lotus\lotus-bot`
-4. Open the folder in cmd or PowerShell
-5. Then `copy .env.example .env`
-6. Modify `.env` with the required API key(s) for the bot(s) you want to run.
-7. Install dependencies: `npm install`
-8. Initialize the Database:
-
-```
-npx prisma migrate dev --name init
-sqlite3 ./prisma/dev.db 'PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;'
-```
-
-### Install (Mac)
-
-1. TBD
 
 ## Runtime Notes
 
@@ -94,16 +53,6 @@ give    .......... Give Lotus to another user
 ### On-Chain Giving
 
 Starting with v2.1.0, the "give" interaction of lotus-bot is now done on-chain. The Give database table is now simply used for tracking gives rather than for calculating user balances. User balances are now calculated solely by the UTXOs of the user's `WalletKey`.
-
-### Write-Ahead Logging on sqlite3
-
-We require the sqlite3 package in order to enable Write-Ahead Logging (WAL) on the Prisma-generated sqlite database. We do this so that you can run multiple instances of the bot on the same sqlite database (i.e. to safely handle simultaneous write operations).
-
-More information about WAL can be found [here](https://www.sqlite.org/wal.html)
-
-**NOTE**: Since v2.0.0, WAL is no longer required, but the PRAGMA changes are still part of the install for helping ensure database integrity.
-
-**WAL is enabled by default with Prisma on Windows[?]**
 
 ### Support / Questions
 

--- a/install/lotus-bot.service
+++ b/install/lotus-bot.service
@@ -5,11 +5,11 @@ After=network.target
 [Service]
 Type=exec
 ExitType=cgroup
-User=lotus-bot
+User=lotusbot
 Group=%G
-PIDFile=/opt/lotus-bot/tmp/lotus-bot.pid
-WorkingDirectory=/opt/lotus-bot/
-ExecStartPre=/opt/lotus-bot/node_modules/typescript/bin/tsc
+PIDFile=/opt/lotusbot/tmp/lotus-bot.pid
+WorkingDirectory=/opt/lotusbot/
+ExecStartPre=/opt/lotusbot/node_modules/typescript/bin/tsc
 ExecStart=node index.js
 ExecStop=/usr/bin/kill -SIGINT $MAINPID
 Restart=on-failure


### PR DESCRIPTION
FIXES:
- README Instructions
- Manual installation method removed
- Installer now runs on the latest Ubuntu 24.04 LTS
- PostgreSQL and git now listed as prerequisites, SQLite3 and manual methods removed to be rewritten later
- Service Unit file reworked to match the latest installer

TODO:
- Update readme with new manual instructions
- Write Docker Compose file for easier setup
- Add error handling and dependency checks in install.sh