### PR TITLE
Adjust `Config` module initialization

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -20,9 +20,9 @@ type ParsedConfig = {
   dbUrl: string
 }
 
-class Config {
-  constructor() {
-    dotenv()
+export class Config {
+  constructor(path?: string) {
+    dotenv({ path })
   }
 
   get parsedConfig() {
@@ -52,5 +52,5 @@ class Config {
   }
 }
 
-const config = new Config()
+const config = new Config('./.env')
 export default config.parsedConfig


### PR DESCRIPTION
Add optional `path` string to the constructor. This is useful if initializing a `LotusBot` configuration using an `.env` file in a different repository.