### PR TITLE
Telegram: Disallow `/give` in response to channel messages

### DIFF
--- a/lib/platforms/telegram.ts
+++ b/lib/platforms/telegram.ts
@@ -331,6 +331,14 @@ export class Telegram implements Platform {
       const fromUsername =
         ctx.message.from.username || ctx.message.from.first_name
       const repliedMessage = <Message>(<any>ctx.message).reply_to_message
+      // bugfix: don't allow giving to channel messages
+      if (repliedMessage.sender_chat?.type === 'channel') {
+        return await ctx.sendMessage(BOT.MESSAGE.ERR_GIVE_TO_CHANNEL_DISALLOWED, {
+          reply_parameters: {
+            message_id: replyToMessageId,
+          },
+        })
+      }
       const toId = repliedMessage?.from?.id
       const toUsername =
         repliedMessage?.from?.username || repliedMessage?.from?.first_name

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -9,6 +9,7 @@ export const BOT = {
     ERR_MUST_GIVE_TO_OTHER_USER: 'You cannot give Lotus to yourself. :)',
     ERR_GIVE_MUST_REPLY_TO_USER:
       'You must reply to another user to give Lotus.',
+    ERR_GIVE_TO_CHANNEL_DISALLOWED: `You cannot give Lotus to a Telegram channel.`,
     ERR_AMOUNT_INVALID: 'Invalid amount specified.',
     ERR_GIVE_TO_BOT:
       'I appreciate the thought, but you cannot give me Lotus. :)',


### PR DESCRIPTION
It was observed that one could /give to a Telegram channel. Only users should be given Lotus. Telegram should start mining instead.