### PR TITLE
Allow giving to `lotus-bot` account as donation

### DIFF
--- a/lib/handler.ts
+++ b/lib/handler.ts
@@ -106,17 +106,32 @@ export class Handler extends EventEmitter {
     const { userId } = await this._getIds(platform, platformId)
     return this.wallet.getXAddress(userId)
   }
-
-  processGiveCommand = async (
-    platform: PlatformName,
-    fromId: string,
-    fromUsername: string,
-    toId: string,
-    toUsername: string,
-    value: string,
-  ) => {
+  /**
+   *
+   * @param param0
+   * @returns
+   */
+  processGiveCommand = async ({
+    platform,
+    chatId,
+    fromId,
+    fromUsername,
+    toId,
+    toUsername,
+    value,
+    isBotDonation,
+  }: {
+    platform: PlatformName
+    chatId?: number
+    fromId: string
+    fromUsername: string
+    toId: string
+    toUsername: string
+    value: string
+    isBotDonation: boolean
+  }) => {
     const sats = Util.toSats(value)
-    const msg = `${fromId}: give: ${fromUsername} -> ${toId} (${toUsername}): ${sats} sats`
+    const msg = `chatId ${chatId}: fromId ${fromId}: give: ${fromUsername} -> ${toId} (${toUsername}): ${sats} sats`
     this.log(platform, `${msg}: command received`)
     if (sats < MIN_OUTPUT_AMOUNT) {
       throw new Error(`${msg}: ERROR: minimum required: ${MIN_OUTPUT_AMOUNT}`)
@@ -130,8 +145,10 @@ export class Handler extends EventEmitter {
     if (sats > balance) {
       throw new Error(`${msg}: ERROR: insufficient balance: ${balance}`)
     }
-    // Create account for toId if not exist
-    const { userId: toUserId } = await this._getIds(platform, toId)
+    // If this is donation to bot, pull that wallet key without db query
+    const toUserId = isBotDonation
+      ? BOT.USER.userId
+      : (await this._getIds(platform, toId)).userId
     // Give successful; broadcast tx and save to db
     const tx = await this.wallet.genTx('give', {
       fromAccountId,

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -21,6 +21,10 @@ export const BOT = {
     ERR_AMOUNT_INVALID: 'Invalid amount specified.',
     ERR_GIVE_TO_BOT:
       'I appreciate the thought, but you cannot give me Lotus. :)',
+    DONATION:
+      `%s, you have donated %s XPI %s! 🪷\r\n\r\n` +
+      `The community fund grows ever larger. Your generosity is greatly appreciated!\r\n\r\n` +
+      `[View tx on the Explorer](%s)`,
     GIVE:
       `%s, you have given %s XPI to %s! 🪷\r\n\r\n` +
       `[View tx on the Explorer](%s)`,


### PR DESCRIPTION
As part of the Temporal integration, the wallet associated to the `lotus-bot` instance will be used for community engagement rewards, etc. This branch implements changes to allow users to donate to this community fund by giving Lotus to the bot directly.