### PR TITLE
Batch engagement rewards in `sendLotus` Temporal activity

### DIFF
--- a/lib/lotusbot.ts
+++ b/lib/lotusbot.ts
@@ -253,15 +253,12 @@ export default class LotusBot {
       return await this.bots[platform].sendMessage(chatId, message)
     },
     /**
-     * Activity to send `sats` amount of Lotus to the specified `scriptPayload`
-     * @param param0
-     * @returns {Promise<string>} Transaction ID returned from Chronik `broadcastTx`
+     * Activity to send outbound `Lotus` transaction to the specified `outputs`
+     * @param outputs - Array of outputs to send
+     * @returns Transaction ID of the broadcasted transaction
      */
-    sendLotus: async ({
-      scriptPayload,
-      sats,
-    }: Temporal.SendLotusInput): Promise<string> => {
-      return await this.handler.temporal.sendLotus({ scriptPayload, sats })
+    sendLotus: async (outputs: Temporal.SendLotusInput[]): Promise<string> => {
+      return await this.handler.temporal.sendLotus(outputs)
     },
     /**
      *

--- a/util/functions.ts
+++ b/util/functions.ts
@@ -1,0 +1,11 @@
+/**
+ * Async generator to iterate over a collection in chunks
+ * @param collection - The collection to iterate over
+ * @param chunkSize - The size of each chunk
+ * @returns An async generator that yields chunks of the collection
+ */
+export async function* asyncCollection<T>(collection: T[]): AsyncIterable<T> {
+  for (let i = 0; i < collection.length; i++) {
+    yield collection[i]
+  }
+}

--- a/util/types.ts
+++ b/util/types.ts
@@ -7,12 +7,13 @@ export namespace Temporal {
     command: string
     data: string[]
   }
+  /** Input received from Temporal Workflow, as a single message */
   export type SendMessageInput = {
     platform: PlatformName
     chatId: string
     message: string
   }
-
+  /** Input received from Temporal Workflow, as a single output for a sendLotus activity */
   export type SendLotusInput = {
     scriptPayload: string
     sats: string


### PR DESCRIPTION
Adjust the `sendLotus` Temporal activity to accept an array of 99 outputs for batching engagement rewards in a single tx