### PR TITLE
Add proper UTXO selection to `sendLotus` Activity

### DIFF
--- a/lib/handler.ts
+++ b/lib/handler.ts
@@ -325,9 +325,17 @@ export class Handler extends EventEmitter {
           'p2pkh',
           this.wallet.getScriptHex(BOT.USER.userId),
         )
-      ).map(utxo => this.wallet.toParsedUtxo(utxo))
+      )
+        .map(utxo => this.wallet.toParsedUtxo(utxo))
+        // filter out utxos with less than 10_000 XPI
+        .filter(({ value }) => Number(value) >= 10_000_000000)
+        // sort highest to lowest
+        .sort((a, b) => Number(b.value) - Number(a.value))
       const tx = await WalletManager.craftSendLotusTransaction({
         outputs: asyncCollection(outputs), // 99 outputs + 1 change output = 100 outputs max
+        totalOutputValue: outputs
+          .reduce((acc, { sats }) => acc + Number(sats), 0)
+          .toString(),
         changeAddress,
         utxos,
         inAddress: changeAddress,

--- a/lib/wallet.ts
+++ b/lib/wallet.ts
@@ -439,6 +439,7 @@ export class WalletManager extends EventEmitter {
    */
   static craftSendLotusTransaction = async ({
     outputs,
+    totalOutputValue,
     changeAddress,
     utxos,
     inAddress,
@@ -448,6 +449,7 @@ export class WalletManager extends EventEmitter {
       scriptPayload: string
       sats: string
     }>
+    totalOutputValue: string
     changeAddress: string
     utxos: Wallet.ParsedUtxo[]
     inAddress: string
@@ -472,10 +474,10 @@ export class WalletManager extends EventEmitter {
           script: inScript,
         }),
       )
-      // TODO: add check for input amount
-      /* if (tx.inputAmount > Number(outValue)) {
+      // if input amount is greater than total output value, break
+      if (tx.inputAmount > Number(totalOutputValue)) {
         break
-      } */
+      }
     }
     // add tx outputs
     for await (const output of outputs) {
@@ -491,7 +493,7 @@ export class WalletManager extends EventEmitter {
         }),
       )
     }
-    // sign and deliver
+    // sign and return tx
     tx.sign(signingKey)
     return tx
   }


### PR DESCRIPTION
Add filtering and validation to ensure that the highest value UTXOs are prioritized, and also that we are only using the UTXOs required to fund all outputs appropriately